### PR TITLE
add: colors.tera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 
 resources/
+src/generated/colors

--- a/colors.tera
+++ b/colors.tera
@@ -1,0 +1,37 @@
+---
+whiskers:
+  version: 2.5.1
+  matrix:
+    - flavor
+    - accent
+  filename: "src/generated/colors/{{flavor.identifier}}/{{accent}}.scss"
+---
+
+{%- set palette = flavor.colors -%}
+$text: #{{ palette.text.hex }};
+$subtext0: #{{ palette.subtext0.hex }};
+$subtext1: #{{ palette.subtext1.hex }};
+$overlay0: #{{ palette.overlay0.hex }};
+$overlay1: #{{ palette.overlay1.hex }};
+$overlay2: #{{ palette.overlay2.hex }};
+$surface0: #{{ palette.surface0.hex }};
+$surface1: #{{ palette.surface1.hex }};
+$surface2: #{{ palette.surface2.hex }};
+
+$accent: #{{ palette[accent].hex }};
+
+$arraylist-tag-color: $subtext0;
+
+$menu-button-loader-color: white;
+$clickgui-grid-color: rgba(127, 127, 127, 0.25);
+
+$hotbar-base-color: black;
+$hotbar-text-color: white;
+/* TODO: currently unused */
+$hotbar-experience-color: $green;
+$hotbar-health-color: $red;
+$hotbar-hunger-color: $flamingo;
+
+$menu-account-premium-color: $accent;
+$overlay0: rgba(211, 211, 211, 255);
+$menu-error-color: $red;


### PR DESCRIPTION
So you can generated a `colors.scss` file using whiskers for each catppuccin flavor & accent!
Don't forget to delete the `src/generated` folder once you've copied one of the generated `scss` files and renamed it to `colors.scss`.
Combine this with CI and images generated by `catwalk` and it could be an official port added in the catppuccin org (except you'd might have to revert all your UI changes that aren't related to changing the color to catppuccin (e.g. the array list) in order to be just that, not sure if they'd care about those changes and require them though)!